### PR TITLE
Update hostname and sitemap URLs in prerender configuration and schem…

### DIFF
--- a/apps/suref-web/src/prerender.config.ts
+++ b/apps/suref-web/src/prerender.config.ts
@@ -38,7 +38,7 @@ export const prerenderConfig = {
   routes: getStaticPaths(),
 
   sitemap: {
-    hostname: 'https://suindex.pages.dev',
+    hostname: 'https://su-srd.pages.dev',
     getEntry: (route: string) => {
       if (route === '/') {
         return { priority: 1.0, changefreq: 'weekly' as const }
@@ -59,6 +59,6 @@ export const prerenderConfig = {
   robots: {
     allow: '/',
     disallow: ['/dashboard', '/api'],
-    sitemap: 'https://suindex.pages.dev/sitemap.xml',
+    sitemap: 'https://su-srd.pages.dev/sitemap.xml',
   },
 }

--- a/apps/suref-web/src/routes/schema/$schemaId/index.tsx
+++ b/apps/suref-web/src/routes/schema/$schemaId/index.tsx
@@ -59,7 +59,7 @@ export const Route = createFileRoute('/schema/$schemaId/')({
             '@type': 'Dataset',
             name: schemaName,
             description: `Salvage Union ${schemaName} System Reference Document (SRD) data`,
-            url: `https://suindex.pages.dev/schema/${schemaId}`,
+            url: `https://su-srd.pages.dev/schema/${schemaId}`,
             keywords: ['Salvage Union', 'TTRPG', 'SRD', 'System Reference Document', schemaName],
             creator: {
               '@type': 'Organization',

--- a/apps/suref-web/src/routes/schema/$schemaId/item/$itemId.tsx
+++ b/apps/suref-web/src/routes/schema/$schemaId/item/$itemId.tsx
@@ -56,7 +56,7 @@ export const Route = createFileRoute('/schema/$schemaId/item/$itemId')({
       '@type': 'Article',
       headline: itemName,
       description: metaDescription,
-      url: `https://suindex.pages.dev/schema/${schemaId}/item/${itemId}`,
+      url: `https://su-srd.pages.dev/schema/${schemaId}/item/${itemId}`,
       keywords: [
         'Salvage Union',
         'TTRPG',

--- a/docs/WORKSPACE_VERIFICATION.md
+++ b/docs/WORKSPACE_VERIFICATION.md
@@ -7,16 +7,15 @@ This document confirms that the `suref-web` app is correctly using the local `sa
 ### 1. Workspace Configuration ✅
 
 **Root `package.json`:**
+
 ```json
 {
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ]
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```
 
 **App `package.json`:**
+
 ```json
 {
   "dependencies": {
@@ -28,19 +27,22 @@ This document confirms that the `suref-web` app is correctly using the local `sa
 ### 2. Workspace Linking ✅
 
 The symlink is correctly created:
+
 ```bash
 apps/suref-web/node_modules/salvageunion-reference -> ../../../packages/salvageunion-reference
 ```
 
 Verified with:
+
 ```bash
 readlink -f apps/suref-web/node_modules/salvageunion-reference
-# Output: /Users/jarvis/Code/suindex/packages/salvageunion-reference
+# Output: /Users/jarvis/Code/SU-SRD/packages/salvageunion-reference
 ```
 
 ### 3. Bun Workspace Resolution ✅
 
 Bun correctly identifies the workspace package:
+
 ```bash
 bun pm ls | grep salvageunion-reference
 # Output: ├── salvageunion-reference@workspace:packages/salvageunion-reference
@@ -49,6 +51,7 @@ bun pm ls | grep salvageunion-reference
 ### 4. Vite Configuration ✅
 
 The Vite config includes:
+
 - **Alias**: Explicitly resolves to the local package path
 - **OptimizeDeps exclusion**: Prevents pre-bundling issues
 - **Manual chunking**: Properly bundles the workspace package
@@ -67,6 +70,7 @@ optimizeDeps: {
 ### 5. TypeScript Resolution ✅
 
 TypeScript correctly resolves types from the local package:
+
 ```bash
 bun run typecheck
 # ✅ Exited with code 0
@@ -75,14 +79,16 @@ bun run typecheck
 ### 6. Runtime Import ✅
 
 The package can be imported and used at runtime:
+
 ```javascript
-import { SalvageUnionReference } from 'salvageunion-reference';
+import { SalvageUnionReference } from 'salvageunion-reference'
 // ✅ Works correctly
 ```
 
 ### 7. Build Process ✅
 
 The build process correctly bundles the workspace package:
+
 ```bash
 bun run build
 # ✅ Build succeeds
@@ -92,7 +98,7 @@ bun run build
 
 1. **Bun Workspaces**: When you run `bun install`, Bun detects the `workspace:*` protocol and creates a symlink from `apps/suref-web/node_modules/salvageunion-reference` to `packages/salvageunion-reference`.
 
-2. **Module Resolution**: 
+2. **Module Resolution**:
    - Bun's runtime resolves `salvageunion-reference` through the symlink
    - TypeScript resolves types from `packages/salvageunion-reference/dist/index.d.ts`
    - Vite uses the alias to ensure proper bundling
@@ -108,8 +114,8 @@ bun run build
 ✅ **The `suref-web` app is using the local `salvageunion-reference` package, not a published npm version.**
 
 The workspace protocol (`workspace:*`) ensures that:
+
 - The local package is always used
 - Changes are immediately available after rebuild
 - No version conflicts with published packages
 - TypeScript and Vite resolve correctly
-


### PR DESCRIPTION
…a routes to use the new su-srd domain. Adjust workspace verification documentation for clarity and consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches site domain to su-srd in sitemap/robots and structured data URLs; updates workspace verification docs for clarity.
> 
> - **SEO/Prerender config**:
>   - Update sitemap hostname and robots `sitemap` URL to `https://su-srd.pages.dev` in `apps/suref-web/src/prerender.config.ts`.
>   - Update structured data `url` fields to `https://su-srd.pages.dev/...` in:
>     - `apps/suref-web/src/routes/schema/$schemaId/index.tsx`
>     - `apps/suref-web/src/routes/schema/$schemaId/item/$itemId.tsx`
> - **Docs**:
>   - Refine `docs/WORKSPACE_VERIFICATION.md` formatting and examples (compact workspace array, updated symlink path output, minor style/consistency tweaks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90fb0f5c50e5ab4979f1f45e44c56a3eafec7dae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->