### PR TITLE
feat(titans): equip Iron Lady with mech modules and theme new sources

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -1,14 +1,28 @@
 type ChangelogEntry = {
   date: string
   title: string
-  description: string
+  items: string[]
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-05-12',
+    title: 'Iron Lady modules + custom expansion themes',
+    items: [
+      'Iron Lady (titans) now lists its equipped Mech Modules — Comms Module, IR Night Vision Optics, Firewall — as compact entries you can click through.',
+      'Titans schema accepts optional `systems` and `modules` arrays; both render as compact cards beneath the titan actions.',
+      "New custom themes for Reclamation of the Wastes (wind-blown dust), The Hive (honeycomb mesh), Thatcher's Mech Base (industrial steel grate), and Relics of a Time Gone By (weathered parchment).",
+      'Changelog entries are now rendered as readable bullet lists instead of paragraphs.',
+      'API page documents that appending `.json` to any schema or item URL returns the raw data.',
+    ],
+  },
+  {
     date: '2026-05-11',
     title: 'Salvage Union Starter Set archived',
-    description:
-      "Reclamation of the Wastes and the Asset Pack mini-adventures (Hive, Thatcher's Mech Base, Relics of a Time Gone By) are now reachable: chassis patterns, systems, modules, abilities, equipment, drones, creatures, titans (monsters and bosses), NPCs with unique statblocks, lances, roll tables, and guides. New schemas: `titans` (replaces `bio-titans`; consolidates monster-class and boss-class mech-scale enemies, including Iron Lady) and `pre-made-characters` (six RotW pilots). Mobile schema list pages no longer overflow horizontally.",
+    items: [
+      "Reclamation of the Wastes and the Asset Pack mini-adventures (Hive, Thatcher's Mech Base, Relics of a Time Gone By) are now reachable: chassis patterns, systems, modules, abilities, equipment, drones, creatures, titans (monsters and bosses), NPCs with unique statblocks, lances, roll tables, and guides.",
+      'New schemas: `titans` (replaces `bio-titans`; consolidates monster-class and boss-class mech-scale enemies, including Iron Lady) and `pre-made-characters` (six RotW pilots).',
+      'Mobile schema list pages no longer overflow horizontally.',
+    ],
   },
 ]

--- a/apps/suref-web/src/pages/api.astro
+++ b/apps/suref-web/src/pages/api.astro
@@ -50,6 +50,12 @@ const baseUrl = SITE_URL
           <strong>Base URL:</strong>{' '}
           <code class="rounded bg-su-blue-pale px-1 py-0.5">{baseUrl}</code>
         </p>
+        <p class="rounded-md border-l-4 border-su-orange-dark bg-su-blue-pale px-4 py-3">
+          <strong>Tip:</strong> appending <code class="rounded bg-su-white px-1 py-0.5">.json</code> to any schema URL on this site returns the underlying data. For example,{' '}
+          <code class="rounded bg-su-white px-1 py-0.5">/schema/chassis</code> renders the HTML index, and{' '}
+          <code class="rounded bg-su-white px-1 py-0.5">/schema/chassis.json</code> serves the raw array. The same applies to individual entities:{' '}
+          <code class="rounded bg-su-white px-1 py-0.5">/schema/chassis/item/iron-mongrel.json</code>.
+        </p>
       </section>
 
       <!-- Endpoints -->

--- a/apps/suref-web/src/pages/changelog.astro
+++ b/apps/suref-web/src/pages/changelog.astro
@@ -51,7 +51,7 @@ const breadcrumbs = [
 
       <ol class="flex flex-col gap-6">
         {CHANGELOG.map((entry) => (
-          <li class="flex flex-col gap-1 border-l-4 border-su-black pl-4">
+          <li class="flex flex-col gap-2 border-l-4 border-su-black pl-4">
             <time
               datetime={entry.date}
               class="font-mono text-xs font-bold uppercase tracking-wide text-su-grey-dark"
@@ -61,7 +61,11 @@ const breadcrumbs = [
             <h2 class="font-mono text-lg font-bold uppercase leading-tight">
               {entry.title}
             </h2>
-            <p class="text-sm leading-relaxed">{entry.description}</p>
+            <ul class="flex list-disc flex-col gap-1.5 pl-5 text-sm leading-relaxed marker:text-su-orange-dark">
+              {entry.items.map((item) => (
+                <li>{item}</li>
+              ))}
+            </ul>
           </li>
         ))}
       </ol>

--- a/packages/salvageunion-reference/data/titans.json
+++ b/packages/salvageunion-reference/data/titans.json
@@ -282,23 +282,13 @@
       "TRIDENT Defence System (The Iron Lady)",
       "M.I.L.K. Injector (The Iron Lady)",
       "Control Signal (The Iron Lady)",
-      "Titanic Actions (The Iron Lady)",
-      "Comms Module",
-      "IR Night Vision Optics",
-      "Firewall"
+      "Titanic Actions (The Iron Lady)"
     ],
+    "modules": ["Comms Module", "IR Night Vision Optics", "Firewall"],
     "content": [
       {
         "type": "paragraph",
         "value": "A monstrous mecha-android built specifically to house the Thatcher Steel CEO. A reinforced glass cockpit reveals her emaciated body, allowing her worshippers to look upon her terrible visage. Sustained far beyond her mortal years, she requires only 4 hours sleep."
-      },
-      {
-        "type": "heading",
-        "value": "Mech Modules"
-      },
-      {
-        "type": "paragraph",
-        "value": "The Iron Lady is equipped with the following standard Mech Modules, which may be used per their standard rules: Comms Module, IR Night Vision, Firewall."
       }
     ]
   }

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -101,6 +101,8 @@ export const TitanSchema = BaseEntitySchema.extend({
     ),
   structurePoints: PositiveIntegerSchema.describe('Structure points of this titan'),
   actions: z.array(z.string()).describe('Action names this titan can perform'),
+  systems: z.array(z.string()).describe('Mech system names this titan is equipped with').optional(),
+  modules: z.array(z.string()).describe('Mech module names this titan is equipped with').optional(),
   traits: z.array(TraitSchema).describe('Traits and special properties').optional(),
 })
   .strict()

--- a/packages/salvageunion-reference/schemas/titans.schema.json
+++ b/packages/salvageunion-reference/schemas/titans.schema.json
@@ -219,6 +219,16 @@
         "items": { "type": "string" },
         "description": "Action names this titan can perform"
       },
+      "systems": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Mech system names this titan is equipped with"
+      },
+      "modules": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Mech module names this titan is equipped with"
+      },
       "traits": {
         "type": "array",
         "items": {

--- a/packages/salvageunion-reference/tools/validateOrphans.ts
+++ b/packages/salvageunion-reference/tools/validateOrphans.ts
@@ -112,12 +112,14 @@ const referencedSystemNames = collectReferencedSystemNames({
   chassis,
   vehicles,
   drones,
+  titans,
   allSystemNames,
 })
 
 const referencedModuleNames = collectReferencedModuleNames({
   chassis,
   drones,
+  titans,
   allModuleNames,
 })
 

--- a/packages/salvageunion-reference/tools/validateOrphansLogic.ts
+++ b/packages/salvageunion-reference/tools/validateOrphansLogic.ts
@@ -95,12 +95,14 @@ type CollectReferencedSystemsInput = {
   chassis: EntityEntry[]
   vehicles: EntityEntry[]
   drones: EntityEntry[]
+  /** Mech-scale boss/monster entries that may be equipped with named systems */
+  titans?: EntityEntry[]
   /** Optional: the full set of known system names — used to disambiguate drone.systems entries */
   allSystemNames?: Set<string>
 }
 
 /**
- * Traverse chassis patterns, vehicles, and drones to collect all referenced system names.
+ * Traverse chassis patterns, vehicles, drones, and titans to collect all referenced system names.
  */
 export function collectReferencedSystemNames(input: CollectReferencedSystemsInput): Set<string> {
   const referenced = new Set<string>()
@@ -164,6 +166,18 @@ export function collectReferencedSystemNames(input: CollectReferencedSystemsInpu
     }
   }
 
+  // Titan-equipped systems
+  if (input.titans) {
+    for (const titan of input.titans) {
+      const systems = titan.systems
+      if (Array.isArray(systems)) {
+        for (const s of systems) {
+          if (typeof s === 'string') referenced.add(s)
+        }
+      }
+    }
+  }
+
   return referenced
 }
 
@@ -172,6 +186,8 @@ export function collectReferencedSystemNames(input: CollectReferencedSystemsInpu
 type CollectReferencedModulesInput = {
   chassis: EntityEntry[]
   drones: EntityEntry[]
+  /** Mech-scale boss/monster entries that may be equipped with named modules */
+  titans?: EntityEntry[]
   /** Optional: the full set of known module names — used to disambiguate drone.systems entries */
   allModuleNames?: Set<string>
 }
@@ -223,6 +239,18 @@ export function collectReferencedModuleNames(input: CollectReferencedModulesInpu
         if (typeof s !== 'string') continue
         if (input.allModuleNames && input.allModuleNames.has(s)) {
           referenced.add(s)
+        }
+      }
+    }
+  }
+
+  // Titan-equipped modules
+  if (input.titans) {
+    for (const titan of input.titans) {
+      const modules = titan.modules
+      if (Array.isArray(modules)) {
+        for (const m of modules) {
+          if (typeof m === 'string') referenced.add(m)
         }
       }
     }

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -162,6 +162,25 @@ export function ReferenceEntityDisplayContent({
     ? SalvageUnionReference.findIn('drones', (d) => d.name === droneAbility.drone)
     : undefined
 
+  // Resolve titan-equipped systems/modules into entities for inline listing
+  const isTitan = schemaName === 'titans'
+  const titanSystemNames =
+    isTitan && 'systems' in data && Array.isArray(data.systems)
+      ? (data.systems as string[])
+      : undefined
+  const titanModuleNames =
+    isTitan && 'modules' in data && Array.isArray(data.modules)
+      ? (data.modules as string[])
+      : undefined
+  const titanSystems = titanSystemNames
+    ?.map((name) => SalvageUnionReference.findIn('systems', (s) => s.name === name))
+    .filter((entity): entity is NonNullable<typeof entity> => !!entity)
+  const titanModules = titanModuleNames
+    ?.map((name) => SalvageUnionReference.findIn('modules', (m) => m.name === name))
+    .filter((entity): entity is NonNullable<typeof entity> => !!entity)
+  const hasTitanEquipment =
+    (titanSystems && titanSystems.length > 0) || (titanModules && titanModules.length > 0)
+
   // Pre-built block for chassis abilities (reused at multiple render positions)
   // When abilitiesSection is provided by the caller, it replaces the entire built-in block
   const chassisAbilitiesBlock = abilitiesSection ? (
@@ -189,6 +208,7 @@ export function ReferenceEntityDisplayContent({
     !!afterExtraContent ||
     !!afterChoicesContent ||
     !!droneEntity ||
+    hasTitanEquipment ||
     hasFactionContent ||
     hasGuideSteps ||
     ('bonusPerTechLevel' in data && !!data.bonusPerTechLevel) ||
@@ -438,6 +458,37 @@ export function ReferenceEntityDisplayContent({
                 headerBg={headerBg}
                 sectionHeaders={schemaName === 'crawlers'}
               />
+            )}
+            {/* Titan-equipped systems/modules render as compact listings under actions */}
+            {titanSystems && titanSystems.length > 0 && (
+              <>
+                <SectionSeparator label="Mech Systems" compact={compact} />
+                <div className={cn('flex flex-col', spacing.sectionSpaceYClass)}>
+                  {titanSystems.map((system) => (
+                    <ReferenceEntityDisplay
+                      key={`titan-system-${system.id}`}
+                      data={system}
+                      compact
+                      listing
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+            {titanModules && titanModules.length > 0 && (
+              <>
+                <SectionSeparator label="Mech Modules" compact={compact} />
+                <div className={cn('flex flex-col', spacing.sectionSpaceYClass)}>
+                  {titanModules.map((mod) => (
+                    <ReferenceEntityDisplay
+                      key={`titan-module-${mod.id}`}
+                      data={mod}
+                      compact
+                      listing
+                    />
+                  ))}
+                </div>
+              </>
             )}
             {/* Compact: chassis abilities render after actions */}
             {compact && chassisAbilitiesBlock}

--- a/packages/suref-react/src/components/referenceEntity/referenceEntityHelpers.ts
+++ b/packages/suref-react/src/components/referenceEntity/referenceEntityHelpers.ts
@@ -126,6 +126,14 @@ export function getSourceBorderColor(source: SURefEnumSource | undefined): strin
       return 'rgb(25, 55, 30)'
     case 'Salvage Union Starter Set':
       return 'rgb(25, 55, 30)'
+    case 'Reclamation of the Wastes':
+      return 'rgb(110, 80, 45)'
+    case 'The Hive':
+      return 'rgb(140, 95, 25)'
+    case "Thatcher's Mech Base":
+      return 'rgb(50, 55, 65)'
+    case 'Relics of a Time Gone By':
+      return 'rgb(85, 70, 50)'
     default:
       return undefined
   }
@@ -166,6 +174,14 @@ export function getSourceStyles(
         return { className: 'expansion-scanline-card', style: {} }
       case 'Salvage Union Starter Set':
         return { className: 'expansion-scanline-card', style: {} }
+      case 'Reclamation of the Wastes':
+        return { className: 'expansion-wastes-card', style: {} }
+      case 'The Hive':
+        return { className: 'expansion-hive-card', style: {} }
+      case "Thatcher's Mech Base":
+        return { className: 'expansion-mechbase-card', style: {} }
+      case 'Relics of a Time Gone By':
+        return { className: 'expansion-relics-card', style: {} }
       default:
         return { className: '', style: {} }
     }
@@ -205,6 +221,30 @@ export function getSourceStyles(
     case 'Salvage Union Starter Set': {
       return {
         className: 'expansion-scanline-texture',
+        style: {},
+      }
+    }
+    case 'Reclamation of the Wastes': {
+      return {
+        className: 'expansion-wastes-texture',
+        style: {},
+      }
+    }
+    case 'The Hive': {
+      return {
+        className: 'expansion-hive-texture',
+        style: {},
+      }
+    }
+    case "Thatcher's Mech Base": {
+      return {
+        className: 'expansion-mechbase-texture',
+        style: {},
+      }
+    }
+    case 'Relics of a Time Gone By': {
+      return {
+        className: 'expansion-relics-texture',
         style: {},
       }
     }

--- a/packages/suref-react/src/styles/theme.css
+++ b/packages/suref-react/src/styles/theme.css
@@ -199,6 +199,171 @@
   pointer-events: none;
 }
 
+/* Reclamation of the Wastes — Wind-blown dust & ochre haze
+   Wide low-angle striations evoking sandblasted metal in the Caldera basin.
+   Warm desaturated tones with a faint speckle layer for grit. */
+.expansion-wastes-texture {
+  position: relative;
+  box-shadow:
+    inset 0 1px 0 0 rgba(120, 95, 60, 0.18),
+    inset 0 -1px 0 0 rgba(60, 45, 30, 0.12);
+}
+.expansion-wastes-texture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    /* Wind-driven dust streaks — long shallow horizontal sweeps */
+    repeating-linear-gradient(
+      -8deg,
+      transparent 0px,
+      transparent 18px,
+      rgba(140, 105, 60, 0.1) 18px,
+      rgba(140, 105, 60, 0.13) 21px,
+      transparent 21px,
+      transparent 36px,
+      rgba(110, 80, 45, 0.07) 36px,
+      rgba(110, 80, 45, 0.09) 38px,
+      transparent 38px,
+      transparent 64px
+    ),
+    /* Counter-sweep — slightly steeper, lighter */
+    repeating-linear-gradient(
+        6deg,
+        transparent 0px,
+        transparent 28px,
+        rgba(180, 140, 90, 0.06) 28px,
+        rgba(180, 140, 90, 0.08) 30px,
+        transparent 30px,
+        transparent 60px
+      );
+  pointer-events: none;
+}
+
+/* The Hive — Honeycomb mesh
+   Two crossing 60°/-60° linear gradients form a diamond/hexagonal weave.
+   Amber undertone evokes hexagonal wax cells. */
+.expansion-hive-texture {
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(140, 95, 25, 0.18);
+}
+.expansion-hive-texture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      60deg,
+      transparent 0px,
+      transparent 9px,
+      rgba(160, 110, 30, 0.1) 9px,
+      rgba(160, 110, 30, 0.12) 10px,
+      transparent 10px,
+      transparent 20px
+    ),
+    repeating-linear-gradient(
+      -60deg,
+      transparent 0px,
+      transparent 9px,
+      rgba(160, 110, 30, 0.1) 9px,
+      rgba(160, 110, 30, 0.12) 10px,
+      transparent 10px,
+      transparent 20px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 17px,
+      rgba(180, 130, 40, 0.06) 17px,
+      rgba(180, 130, 40, 0.07) 18px,
+      transparent 18px,
+      transparent 36px
+    );
+  pointer-events: none;
+}
+
+/* Thatcher's Mech Base — Industrial steel grate
+   Heavy horizontal bands like floor grating, plus thinner cross-pinstripes
+   for a riveted-plate feel. Cold grey-blue undertone. */
+.expansion-mechbase-texture {
+  position: relative;
+  box-shadow:
+    inset 0 0 0 2px rgba(60, 65, 75, 0.2),
+    inset 0 1px 0 0 rgba(180, 185, 195, 0.15);
+}
+.expansion-mechbase-texture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    /* Horizontal grate bands — wide, even spacing */
+    repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 6px,
+      rgba(40, 50, 60, 0.16) 6px,
+      rgba(40, 50, 60, 0.18) 7px,
+      transparent 7px,
+      transparent 14px
+    ),
+    /* Vertical pinstripe cross-hatch — thinner, denser */
+    repeating-linear-gradient(
+        90deg,
+        transparent 0px,
+        transparent 22px,
+        rgba(40, 50, 60, 0.08) 22px,
+        rgba(40, 50, 60, 0.1) 23px,
+        transparent 23px,
+        transparent 46px
+      );
+  pointer-events: none;
+}
+
+/* Relics of a Time Gone By — Weathered parchment
+   Soft sepia overlay with irregular hairline cracks across the surface.
+   Warm aged-paper undertone, gentler than other textures. */
+.expansion-relics-texture {
+  position: relative;
+  box-shadow:
+    inset 0 0 0 1px rgba(85, 70, 50, 0.15),
+    inset 0 0 12px 2px rgba(85, 70, 50, 0.08);
+}
+.expansion-relics-texture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    /* Sparse hairline cracks — irregular angles to feel non-mechanical */
+    repeating-linear-gradient(
+      18deg,
+      transparent 0px,
+      transparent 46px,
+      rgba(85, 70, 50, 0.08) 46px,
+      rgba(85, 70, 50, 0.1) 47px,
+      transparent 47px,
+      transparent 92px
+    ),
+    repeating-linear-gradient(
+      -34deg,
+      transparent 0px,
+      transparent 58px,
+      rgba(85, 70, 50, 0.06) 58px,
+      rgba(85, 70, 50, 0.08) 58.5px,
+      transparent 58.5px,
+      transparent 110px
+    ),
+    repeating-linear-gradient(
+      72deg,
+      transparent 0px,
+      transparent 80px,
+      rgba(85, 70, 50, 0.05) 80px,
+      rgba(85, 70, 50, 0.07) 81px,
+      transparent 81px,
+      transparent 150px
+    );
+  pointer-events: none;
+}
+
 /* === Expansion Card-Level Shadows ===
    Each replaces the default shadow-lg on the outer card wrapper. */
 
@@ -229,6 +394,34 @@
   box-shadow:
     0 0 8px 1px rgba(25, 55, 30, 0.18),
     0 2px 8px -1px rgba(0, 0, 0, 0.2);
+}
+
+/* Reclamation of the Wastes — warm dust-haze halo */
+.expansion-wastes-card {
+  box-shadow:
+    0 4px 14px -2px rgba(120, 85, 45, 0.32),
+    0 2px 6px -1px rgba(120, 85, 45, 0.16);
+}
+
+/* The Hive — warm amber comb-glow */
+.expansion-hive-card {
+  box-shadow:
+    0 0 10px 1px rgba(180, 130, 35, 0.22),
+    0 3px 8px -1px rgba(85, 60, 15, 0.22);
+}
+
+/* Thatcher's Mech Base — heavy industrial drop shadow */
+.expansion-mechbase-card {
+  box-shadow:
+    4px 5px 0 -1px rgba(25, 30, 40, 0.35),
+    0 2px 6px 0 rgba(0, 0, 0, 0.18);
+}
+
+/* Relics of a Time Gone By — soft sepia age glow */
+.expansion-relics-card {
+  box-shadow:
+    0 3px 12px -2px rgba(85, 70, 50, 0.3),
+    0 1px 4px 0 rgba(85, 70, 50, 0.15);
 }
 
 /* Mobile-first touch targets */


### PR DESCRIPTION
## Summary

- **TitanSchema**: optional `systems` and `modules` arrays so titans can reference equipped mech-scale gear by name.
- **Iron Lady**: equipped with Comms Module, IR Night Vision Optics, and Firewall (replaces redundant prose with structured data).
- **Rendering**: titan-equipped systems/modules render as compact entity listings beneath the titan actions, gated on `schemaName === 'titans'` so drone/vehicle `systems` arrays are unaffected.
- **Orphan validator**: now considers titan-equipped systems/modules so newly equipped entries aren't flagged.
- **Source themes**: custom expansion textures for Reclamation of the Wastes (wind-blown dust), The Hive (honeycomb mesh), Thatcher's Mech Base (industrial steel grate), and Relics of a Time Gone By (weathered parchment).
- **Changelog**: each entry is now an array of bullet items rather than a paragraph; the prior 2026-05-11 entry is migrated and a 2026-05-12 entry covers this PR.
- **API page**: documents that appending `.json` to any schema or item URL returns the underlying data.

## Test plan

- [ ] Open Iron Lady on the SRD reference site; confirm the three modules render as compact cards below the titan actions and clicking them opens the module detail.
- [ ] Confirm the prose "Mech Modules — The Iron Lady is equipped with…" is no longer duplicated in content (the structured listing replaces it).
- [ ] Open a chassis with patterns or a vehicle/drone with `systems` arrays; confirm the new titan-only listing block does NOT render for them.
- [ ] Open one entity from each new source (Reclamation of the Wastes, The Hive, Thatcher's Mech Base, Relics of a Time Gone By); confirm header texture renders and is distinct from the others.
- [ ] Visit `/changelog`; confirm both entries render as bullet lists with orange markers.
- [ ] Visit `/api`; confirm the JSON-URL tip callout appears in the Overview section.
- [ ] `bun run validate:all` shows no new orphans for the three Iron Lady modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)